### PR TITLE
Allow more natural updating of values

### DIFF
--- a/Mars.cabal
+++ b/Mars.cabal
@@ -74,11 +74,15 @@ Test-suite test-mars
     Main-is: Main.hs
     other-modules:
       Mars.Command
+      Mars.Eval
+      Mars.Instances
       Mars.Parser
       Mars.Types
       Tests.Mars.Arbitraries
     autogen-modules:
       Mars.Command
+      Mars.Eval
+      Mars.Instances
       Mars.Parser
       Mars.Types
       Tests.Mars.Arbitraries
@@ -87,6 +91,7 @@ Test-suite test-mars
     Build-depends: QuickCheck
                   , Mars
                   , aeson
+                  , aeson-pretty
                   , attoparsec
                   , base
                   , bytestring
@@ -98,6 +103,7 @@ Test-suite test-mars
                   , tasty-quickcheck
                   , text
                   , unordered-containers
+                  , url
                   , vector
 
 source-repository head

--- a/src/Client/Main.hs
+++ b/src/Client/Main.hs
@@ -1,20 +1,22 @@
-{-# LANGUAGE OverloadedStrings, CPP #-}
-module Main
-where
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Main where
+
 import Control.Applicative ()
+import Control.Exception
 import Control.Monad
 import Data.Aeson
+import qualified Data.ByteString.Lazy.Char8 as ByteString
+import qualified Data.Text as Text
+import Data.Text.IO as TIO
 import Mars.Eval
 import Mars.Parser
 import Mars.Types
 import Options.Applicative
 import System.Console.Haskeline
 import System.Console.Haskeline.IO
-import Control.Exception
 import System.IO as SIO
-import Data.Text.IO as TIO
-import qualified Data.ByteString.Lazy.Char8 as ByteString
-import qualified Data.Text as Text
 
 #ifdef WINDOWS
 readline :: String -> IO (Maybe String)
@@ -35,75 +37,80 @@ testTTY :: IO Bool
 testTTY = hIsTerminalDevice stdin
 #endif
 
-data Mars = Mars { jsonFilename :: String, noninteractive :: Bool }
+data Mars = Mars {jsonFilename :: String, noninteractive :: Bool}
 
 -- | The initial state
 initialState :: MarsState
-initialState = MarsState { path = Query []
-                         , document = Nothing
-                         }
+initialState =
+  MarsState
+    { path = DefaultLocation,
+      document = Nothing
+    }
 
 main :: IO ()
 main = execParser opts >>= runWithOptions
-    where
-        opts = info optParser mempty
-        optParser = Mars
-                <$> argument str (metavar "filename")
-                <*> switch (short 'n'
-                        <> long "noninteractive"
-                        <> help "Force noninteractive mode")
+  where
+    opts = info optParser mempty
+    optParser =
+      Mars
+        <$> argument str (metavar "filename")
+        <*> switch
+          ( short 'n'
+              <> long "noninteractive"
+              <> help "Force noninteractive mode"
+          )
 
 runWithOptions :: Mars -> IO ()
 runWithOptions opts = do
-    hSetEncoding stdout utf8
-    isTTY <- testTTY
-    jsonString <- openFileOrStdin . jsonFilename $ opts
-    hFlush stdout
+  hSetEncoding stdout utf8
+  isTTY <- testTTY
+  jsonString <- openFileOrStdin . jsonFilename $ opts
+  hFlush stdout
 
-    if isTTY && not (noninteractive opts)
-        then -- Start an interactive session
-            readEvalPrintLoop $ initialState { document = json2Doc jsonString }
-
-        else
-            do
-                input <- TIO.hGetContents stdin
-                _ <- exec initialState (Text.lines input)
-                return ()
-    where
-        json2Doc :: ByteString.ByteString -> Maybe Value
-        json2Doc = decode
+  if isTTY && not (noninteractive opts)
+    then -- Start an interactive session
+      readEvalPrintLoop $ initialState {document = json2Doc jsonString}
+    else do
+      input <- TIO.hGetContents stdin
+      _ <- exec initialState (Text.lines input)
+      return ()
+  where
+    json2Doc :: ByteString.ByteString -> Maybe Value
+    json2Doc = decode
 
 openFileOrStdin :: String -> IO ByteString.ByteString
 openFileOrStdin fname = do
-    fileHandle <- openFile fname ReadMode
-    contents <- SIO.hGetContents fileHandle
-    return . ByteString.pack $ contents
+  fileHandle <- openFile fname ReadMode
+  contents <- SIO.hGetContents fileHandle
+  return . ByteString.pack $ contents
 
 exec :: MarsState -> [Text.Text] -> IO MarsState
 exec = foldM eval
 
 readEvalPrintLoop :: MarsState -> IO ()
-readEvalPrintLoop state = bracketOnError (initializeInput defaultSettings)
-            {- This will only be called if an exception such as a SigINT
-             - is received.
-             -}
-            cancelInput
-            (\ hd -> loop hd state >> closeInput hd)
-    where
-        loop :: InputState -> MarsState -> IO ()
-        loop hd s = do
-            minput <- queryInput hd (getInputLine "> ")
-            case minput of
-                Nothing -> return ()
-                Just "quit" -> return ()
-                Just input -> do
-                                s' <- eval s $ Text.pack input
-                                loop hd s'
+readEvalPrintLoop state =
+  bracketOnError
+    (initializeInput defaultSettings)
+    {- This will only be called if an exception such as a SigINT
+     - is received.
+     -}
+    cancelInput
+    (\hd -> loop hd state >> closeInput hd)
+  where
+    loop :: InputState -> MarsState -> IO ()
+    loop hd s = do
+      minput <- queryInput hd (getInputLine "> ")
+      case minput of
+        Nothing -> return ()
+        Just "quit" -> return ()
+        Just input -> do
+          s' <- eval s $ Text.pack input
+          loop hd s'
 
 eval :: MarsState -> Text.Text -> IO MarsState
 eval s input = case parser input of
-            Left err -> do
-                        print err
-                        return s
-            Right [] -> return s
-            Right (x : _) -> run s x
+  Left err -> do
+    print err
+    return s
+  Right [] -> return s
+  Right (x : _) -> run s x

--- a/src/Mars/Parser.hs
+++ b/src/Mars/Parser.hs
@@ -4,6 +4,7 @@
 
 module Mars.Parser where
 
+import Data.Maybe
 import Control.Applicative
 import Control.Monad
 import qualified Data.Aeson.Parser as AesonParser
@@ -40,7 +41,7 @@ keyword :: forall u. ParsecT String u Identity Command
 keyword =
   try (Pwd <$ string "pwd")
     <|> try (Cat [] <$ string "cat")
-    <|> try (Ls (mempty) <$ string "ls")
+    <|> try (Ls mempty <$ string "ls")
     <?> "keyword"
 
 keywordWithArg :: forall u. ParsecT String u Identity Command
@@ -54,7 +55,7 @@ keywordWithArg =
           <*> (spaces *> value)
       )
     <|> try (Cd <$> (string "cd" *> spaces *> query))
-    <|> try (Cd (mempty) <$ string "cd")
+    <|> try (Cd mempty <$ string "cd")
     <?> "keyword and argument"
 
 queryString :: forall u. ParsecT String u Identity (String, String)
@@ -64,9 +65,7 @@ query :: forall u. ParsecT String u Identity Query
 query =
   do
     items <- queryItem `sepBy` string (Text.unpack querySeparator)
-    return $ case normalizeQuery items of
-      Just i -> i
-      Nothing -> mempty
+    return $ fromMaybe mempty . normalizeQuery $ items
     <?> "query"
 
 queryItem :: forall u. ParsecT String u Identity UnnormalizedQueryItem

--- a/src/Mars/Types.hs
+++ b/src/Mars/Types.hs
@@ -5,7 +5,6 @@ module Mars.Types
   ( ANSIColour (..),
     Command (..),
     GlobItem (..),
-    Oracle (..),
     MarsState (..),
     Query (..),
     QueryItem (..),

--- a/src/Mars/Types.hs
+++ b/src/Mars/Types.hs
@@ -1,7 +1,16 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
 
-module Mars.Types where
+module Mars.Types
+  ( Query (..),
+    QueryItem (..),
+    UnnormalizedQueryItem (..),
+    Command (..),
+    GlobItem (..),
+    MarsState (..),
+    ANSIColour (..),
+  )
+where
 
 import Data.Aeson.Types
 import Data.List.NonEmpty
@@ -12,11 +21,10 @@ import GHC.Generics
 -- | The datatype representing the queries possible for commands that select
 --  - items
 --  -
-data Query = Query [QueryItem]
+data Query
+  = DefaultLocation
+  | Query (NonEmpty QueryItem)
   deriving (Generic, Show, Eq)
-
-instance Monoid Query where
-  mempty = Query []
 
 -- | A data type representing the primitive commands available in the Mars
 -- repl
@@ -31,11 +39,21 @@ data Command
   deriving (Generic, Show, Eq, Typeable)
 
 instance Semigroup Query where
+  DefaultLocation <> b = b
+  Query _ <> DefaultLocation = DefaultLocation
   (Query a) <> (Query b) = Query (a <> b)
+
+instance Monoid Query where
+  mempty = DefaultLocation
+
+data UnnormalizedQueryItem
+  = GlobInput (NonEmpty GlobItem)
+  | LevelAbove
+  | CurrentLevel
+  deriving (Generic, Show, Eq)
 
 data QueryItem
   = Glob (NonEmpty GlobItem)
-  | LevelAbove
   deriving (Generic, Show, Eq)
 
 data GlobItem
@@ -50,3 +68,14 @@ data MarsState = MarsState
     document :: Maybe Value
   }
   deriving (Generic)
+
+data ANSIColour
+  = Grey
+  | Red
+  | Green
+  | Yellow
+  | Blue
+  | Magenta
+  | Cyan
+  | White
+  deriving (Show, Eq)

--- a/src/Mars/Types.hs
+++ b/src/Mars/Types.hs
@@ -2,13 +2,14 @@
 {-# LANGUAGE DeriveGeneric #-}
 
 module Mars.Types
-  ( Query (..),
-    QueryItem (..),
-    UnnormalizedQueryItem (..),
+  ( ANSIColour (..),
     Command (..),
     GlobItem (..),
+    Oracle (..),
     MarsState (..),
-    ANSIColour (..),
+    Query (..),
+    QueryItem (..),
+    UnnormalizedQueryItem (..),
   )
 where
 

--- a/src/Mars/Types.hs
+++ b/src/Mars/Types.hs
@@ -52,7 +52,7 @@ data UnnormalizedQueryItem
   | CurrentLevel
   deriving (Generic, Show, Eq)
 
-data QueryItem
+newtype QueryItem
   = Glob (NonEmpty GlobItem)
   deriving (Generic, Show, Eq)
 

--- a/src/Tests/Mars/Arbitraries.hs
+++ b/src/Tests/Mars/Arbitraries.hs
@@ -62,12 +62,9 @@ instance Arbitrary Command where
         Cd <$> arbitrary,
         pure Pwd
       ]
-  shrink = genericShrink
 
--- TODO we are explicitly not testing empty strings here, we really should
 instance Arbitrary Query where
-  arbitrary = Query <$> arbitrary
-  shrink = genericShrink
+  arbitrary = Query . NonEmpty.fromList . Modifiers.getNonEmpty <$> arbitrary
 
 genGlob :: Gen (NonEmpty GlobItem)
 genGlob = do
@@ -79,29 +76,34 @@ genGlob = do
 instance Arbitrary QueryItem where
   arbitrary =
     oneof
-      [ Glob <$> genGlob,
-        pure LevelAbove
+      [ Glob <$> genGlob
       ]
-  shrink (Glob l) =
-    if (NonEmpty.fromList [NonEmpty.head l] == l)
-      then []
-      else [Glob . NonEmpty.fromList $ [NonEmpty.head l]]
-  shrink _ = []
 
 instance Arbitrary GlobItem where
   arbitrary =
     oneof [pure AnyChar, pure AnyCharMultiple]
-  shrink = genericShrink
 
 arbitraryPositiveInt :: Gen Int
 arbitraryPositiveInt = arbitrary `suchThat` (> 0)
 
 instance Arbitrary MarsState where
   arbitrary = MarsState <$> arbitrary <*> arbitrary
-  shrink = genericShrink
 
 arbitraryArray :: Gen Array
 arbitraryArray = Vector.fromList <$> arbitrary
 
 arbitraryObject :: Gen Object
 arbitraryObject = Map.fromList <$> arbitrary
+
+instance Arbitrary ANSIColour where
+  arbitrary =
+    oneof
+      [ pure Grey,
+        pure Red,
+        pure Green,
+        pure Yellow,
+        pure Blue,
+        pure Magenta,
+        pure Cyan,
+        pure White
+      ]

--- a/src/Tests/Mars/Main.hs
+++ b/src/Tests/Mars/Main.hs
@@ -56,28 +56,28 @@ unitTests =
     [ testGroup
         "Parsing Commands"
         [ parseCase "ls" [Ls DefaultLocation],
-          testCase "ls *" $
-            parser "ls *"
-              @?= Right
-                [ Ls
-                    ( Query . NonEmpty.fromList $
-                        [ Glob . NonEmpty.fromList $
-                            [AnyCharMultiple]
-                        ]
-                    )
-                ],
-          testCase
+          parseCase "cat" [Cat []],
+          parseCase "pwd" [Pwd],
+          parseCase "cd" [Cd DefaultLocation],
+          parseCase
+            "ls *"
+            [ Ls
+                ( Query . NonEmpty.fromList $
+                    [ Glob . NonEmpty.fromList $
+                        [AnyCharMultiple]
+                    ]
+                )
+            ],
+          parseCase
             "ls b*"
-            $ parser "ls b*"
-              @?= Right
-                [ Ls
-                    ( Query
-                        . NonEmpty.fromList
-                        $ [ Glob . NonEmpty.fromList $
-                              [LiteralString "b", AnyCharMultiple]
-                          ]
-                    )
-                ]
+            [ Ls
+                ( Query
+                    . NonEmpty.fromList
+                    $ [ Glob . NonEmpty.fromList $
+                          [LiteralString "b", AnyCharMultiple]
+                      ]
+                )
+            ]
         ],
       testGroup
         "Parsing Queries"


### PR DESCRIPTION
A number of the QuickCheck tests indicated that there's a potential
inconsistency around how we're modelling the queries. For example should
`cat` have been parsed as `Cat []` or `Cat [Query []]`.

This is causing a ripple effect out through the code so the diff here is
quite large (and will get larger for a while), but I expect it to
eventually make the code more straight forward.

We also find that we weren't testing `Mars.Eval`, so adding a simple
test for that now, there'll almost certainly be a refactoring (Free
Monad? 🤔) to improve that story too.