### PR TITLE
Allow testing of command effects

### DIFF
--- a/Mars.cabal
+++ b/Mars.cabal
@@ -50,16 +50,39 @@ library
   ghc-options: -O2 -threaded -Wall -Werror
 
 executable mars
-  Hs-Source-Dirs: src/Client
+  Hs-Source-Dirs:
+    src/Client
+    src
   main-is: Main.hs
+  other-modules:
+    Mars.Command
+    Mars.Eval
+    Mars.Instances
+    Mars.Parser
+    Mars.Types
+    Tests.Mars.Arbitraries
+  autogen-modules:
+    Mars.Command
+    Mars.Eval
+    Mars.Instances
+    Mars.Parser
+    Mars.Types
+    Tests.Mars.Arbitraries
   build-depends: Mars
+                 , QuickCheck
+                 , aeson
+                 , aeson-pretty
+                 , attoparsec
                  , base >=3 && < 6
                  , bytestring
-                 , optparse-applicative
-                 , attoparsec
                  , haskeline
+                 , optparse-applicative
+                 , parsec
+                 , string-conv
                  , text
-                 , aeson
+                 , unordered-containers
+                 , url
+                 , vector
   ghc-options: -O2 -rtsopts=all -with-rtsopts=-N -Wall -threaded -Werror
   if os(windows)
     Cpp-options: -DWINDOWS
@@ -87,7 +110,7 @@ Test-suite test-mars
       Mars.Types
       Tests.Mars.Arbitraries
 
-    ghc-options: -O2 -rtsopts=all -with-rtsopts=-N -Wall -threaded -Werror
+    ghc-options: -rtsopts=all -with-rtsopts=-N -Wall -threaded -Werror
     Build-depends: QuickCheck
                   , Mars
                   , aeson

--- a/src/Mars/Command.hs
+++ b/src/Mars/Command.hs
@@ -3,8 +3,7 @@
 
 -- | Types representing items entered at the Mars command line
 module Mars.Command
-  ( directoryEntries,
-    globIndices,
+  ( globIndices,
     globKeys,
     modifyDoc,
     moveUp,
@@ -158,18 +157,6 @@ applyChanges _ _ _ s@(String _) = s
 applyChanges _ _ _ s@(Number _) = s
 applyChanges _ _ _ s@(Bool _) = s
 applyChanges _ _ _ s@Null = s
-
-directoryEntries :: QueryItem -> Value -> [Text]
-directoryEntries (Glob globMap) (Object o) = globKeys o globMap
-directoryEntries (Glob globMap) (Array o) =
-  map
-    (toS . show)
-    . globIndices o
-    $ globMap
-directoryEntries _ (String _) = []
-directoryEntries _ (Number _) = []
-directoryEntries _ (Bool _) = []
-directoryEntries _ Null = []
 
 globKeys :: HashMap Text a -> NonEmpty GlobItem -> [Text]
 globKeys obj glob = filter (match glob) . Map.keys $ obj

--- a/src/Mars/Eval.hs
+++ b/src/Mars/Eval.hs
@@ -2,17 +2,20 @@
 {-# LANGUAGE DoAndIfThenElse #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TupleSections #-}
 
 module Mars.Eval
-  ( run,
-    ls,
-    cd,
-    pwd,
+  ( Output (..),
+    ansiColor,
     cat,
-    update,
-    save,
+    cd,
     load,
-    ansiColour,
+    ls,
+    pwd,
+    run,
+    save,
+    update,
+    directoryEntries,
   )
 where
 
@@ -23,42 +26,57 @@ import Control.Applicative
 import Data.Aeson
 import Data.Aeson.Encode.Pretty
 import qualified Data.ByteString.Lazy.Char8 as ByteString
-import qualified Data.HashMap.Lazy as Map
-import Data.List.NonEmpty (NonEmpty (..))
-import qualified Data.List.NonEmpty as NonEmpty
+import qualified Data.HashMap.Strict as Map
+import Data.Ix
 import Data.Maybe
 import Data.String
 import Data.String.Conv
 import Data.Text (Text)
 import qualified Data.Text as Text
-import Data.Vector ((!?))
+import Data.Text.IO (putStrLn)
+import qualified Data.Vector as Vector
 import Mars.Command
 import Mars.Instances ()
 import Mars.Types
-import System.IO
-import Text.Read (readMaybe)
+import System.IO hiding (putStrLn)
+import Prelude hiding (putStrLn)
+
+newtype Output = Output Text
+  deriving (Show, Eq)
+
+exec :: (MarsState, Output) -> IO MarsState
+exec (newState, Output output) = do
+  putStrLn output
+  return newState
 
 run :: MarsState -> Command -> IO MarsState
-run s (Cat queries) = s <$ cat s queries
-run s Pwd = s <$ pwd s
-run s (Ls query) = s <$ ls s query
-run s (Cd query) = cd s query
-run s (Update query value) = update s query value
-run s (Save filename) = save s filename
+run s (Cat queries) = exec $ cat s queries
+run s (Cd query) = exec $ cd s query
 run s (Load filename) = load s filename
+run s (Ls query) = do
+  putStrLn . toS . show $ query
+  exec $ ls s query
+run s (Save filename) = save s filename
+run s (Update query value) = exec $ update s query value
+run s Pwd = exec $ pwd s
 
 getDocument :: MarsState -> Value
 getDocument s = fromMaybe (object []) $ document s
 
-cat :: MarsState -> [Query] -> IO ()
+cat :: MarsState -> [Query] -> (MarsState, Output)
 cat s [] =
-  putStrLn . (=<<) (ByteString.unpack . encodePretty)
-    . queryDoc (path s)
-    . getDocument
-    $ s
+  ( s,
+    Output . toS
+      . encodePretty
+      . queryDoc (path s)
+      . getDocument
+      $ s
+  )
 cat s l =
-  putStrLn . ByteString.unpack . ByteString.intercalate "\n" $
-    (=<<) formattedJSONText l
+  ( s,
+    Output . toS . ByteString.intercalate "\n" $
+      (=<<) formattedJSONText l
+  )
   where
     formattedJSONText :: Query -> [ByteString.ByteString]
     formattedJSONText q =
@@ -67,8 +85,10 @@ cat s l =
         . getDocument
         $ s
 
-cd :: MarsState -> Query -> IO MarsState
-cd s query = pure s {path = newQuery}
+cd :: MarsState -> Query -> (MarsState, Output)
+cd s query =
+  let newState = s {path = newQuery}
+   in (newState, Output "")
   where
     newQuery
       | itemExists = path s
@@ -78,11 +98,11 @@ cd s query = pure s {path = newQuery}
         . getDocument
         $ s
 
-pwd :: MarsState -> IO ()
-pwd = putStrLn . Text.unpack . renderQuery . path
+pwd :: MarsState -> (MarsState, Output)
+pwd s = (s, Output . renderQuery . path $ s)
 
-update :: MarsState -> Query -> Value -> IO MarsState
-update s query value = return $ s {document = newDoc}
+update :: MarsState -> Query -> Value -> (MarsState, Output)
+update s query value = (s {document = newDoc}, Output "")
   where
     newDoc = doUpdate =<< document s
     doUpdate doc = Just $ modifyDoc doc query value
@@ -103,44 +123,92 @@ load s filename = do
     reportResult (Success state) = pure state
     printErr err = s <$ hPutStrLn stderr ("Invalid saved state: " <> err)
 
-ls :: MarsState -> Query -> IO ()
-ls s q = putStrLn . Text.unpack . format . list (getDocument s) $ path s <> q
+ls :: MarsState -> Query -> (MarsState, Output)
+ls s DefaultLocation = (s, Output . format . list (getDocument s) $ path s)
   where
-    format :: [Text] -> Text
-    format l = Text.intercalate "\n" l
-    list :: Value -> Query -> [Text]
-    list doc DefaultLocation = list doc (Query (Glob (AnyCharMultiple :| []) :| [])) -- 🤔
-    list doc (Query query) =
-      zipWith ansiColour colors entries
-      where
-        entries :: [Text]
-        entries = directoryEntries (NonEmpty.head query) doc
-        colors :: [ANSIColour]
-        colors = map (childColor doc) entries
-        childColor :: Value -> Text -> ANSIColour
-        childColor (Object obj) key = colourMap . fromMaybe Null $ Map.lookup key obj
-        childColor (Array arr) key = colourMap . fromMaybe Null $ do
-          k <- readMaybe . toS $ key
-          arr !? k
-        childColor v _ = colourMap v
+    format :: [DirectoryEntry] -> Text
+    format l =
+      Text.intercalate "\n"
+        . zipWith
+          ansiColor
+          (colorMap <$> l)
+        $ (\(DirectoryEntry (ItemName name) _) -> name) <$> l
+ls s q = (s, Output . format . list (getDocument s) $ path s <> q)
+  where
+    format :: [DirectoryEntry] -> Text
+    format l =
+      Text.intercalate "\n"
+        . zipWith
+          ansiColor
+          (colorMap <$> l)
+        $ (\(DirectoryEntry (ItemName name) _) -> name) <$> l
 
-colourMap :: Value -> ANSIColour
-colourMap (Object _) = Blue
-colourMap (Array _) = Blue
-colourMap (String _) = Green
-colourMap (Number _) = Green
-colourMap (Bool _) = Green
-colourMap Null = Green
+list :: Value -> Query -> [DirectoryEntry]
+list doc query =
+  concatMap directoryEntries . queryDoc query $ doc
 
-ansiColour :: ANSIColour -> Text -> Text
-ansiColour Grey = ansiWrap "30"
-ansiColour Red = ansiWrap "31"
-ansiColour Green = ansiWrap "32"
-ansiColour Yellow = ansiWrap "33"
-ansiColour Blue = ansiWrap "34"
-ansiColour Magenta = ansiWrap "35"
-ansiColour Cyan = ansiWrap "36"
-ansiColour White = ansiWrap "37"
+directoryEntries :: Value -> [DirectoryEntry]
+directoryEntries (Object o) =
+  let toDirectoryEntry :: (Text, Value) -> DirectoryEntry
+      toDirectoryEntry (name, v) =
+        DirectoryEntry
+          (ItemName . toS . show $ name)
+          (toItemType v)
+   in toDirectoryEntry
+        <$> catMaybes
+          ( spreadMaybe
+              <$> spread (o Map.!?) (Map.keys o)
+          )
+directoryEntries (Array o) =
+  let toDirectoryEntry :: (Int, Value) -> DirectoryEntry
+      toDirectoryEntry (name, v) =
+        DirectoryEntry
+          (ItemName . toS . show $ name)
+          (toItemType v)
+   in toDirectoryEntry
+        <$> catMaybes
+          ( spreadMaybe
+              <$> spread (o Vector.!?) ((\x -> range (0, length x)) o)
+          )
+directoryEntries (String _) = []
+directoryEntries (Number _) = []
+directoryEntries (Bool _) = []
+directoryEntries Null = []
+
+spread :: (a -> b) -> [a] -> [(a, b)]
+spread f a = zip a (f <$> a)
+
+extractSpread :: Functor f => (a, f b) -> f (a, b)
+extractSpread (i, l) = (i,) <$> l
+
+spreadMaybe :: (a, Maybe b) -> Maybe (a, b)
+spreadMaybe = extractSpread
+
+colorMap :: DirectoryEntry -> ANSIColour
+colorMap (DirectoryEntry _ MarsObject) = Blue
+colorMap (DirectoryEntry _ MarsList) = Blue
+colorMap (DirectoryEntry _ MarsString) = Green
+colorMap (DirectoryEntry _ MarsNumber) = Green
+colorMap (DirectoryEntry _ MarsBool) = Green
+colorMap (DirectoryEntry _ MarsNull) = Green
+
+ansiColor :: ANSIColour -> Text -> Text
+ansiColor Grey = ansiWrap "30"
+ansiColor Red = ansiWrap "31"
+ansiColor Green = ansiWrap "32"
+ansiColor Yellow = ansiWrap "33"
+ansiColor Blue = ansiWrap "34"
+ansiColor Magenta = ansiWrap "35"
+ansiColor Cyan = ansiWrap "36"
+ansiColor White = ansiWrap "37"
 
 ansiWrap :: forall m. (Monoid m, Data.String.IsString m) => m -> m -> m
-ansiWrap colourID text = "\ESC[" <> colourID <> "m" <> text <> "\ESC[0m"
+ansiWrap colorID text = "\ESC[" <> colorID <> "m" <> text <> "\ESC[0m"
+
+toItemType :: Value -> ItemType
+toItemType (Object _) = MarsObject
+toItemType (Array _) = MarsList
+toItemType (String _) = MarsString
+toItemType (Number _) = MarsNumber
+toItemType (Bool _) = MarsBool
+toItemType Null = MarsNull

--- a/src/Mars/Types.hs
+++ b/src/Mars/Types.hs
@@ -4,7 +4,10 @@
 module Mars.Types
   ( ANSIColour (..),
     Command (..),
+    DirectoryEntry (..),
     GlobItem (..),
+    ItemName (..),
+    ItemType (..),
     MarsState (..),
     Query (..),
     QueryItem (..),
@@ -14,6 +17,7 @@ where
 
 import Data.Aeson.Types
 import Data.List.NonEmpty
+import Data.Text (Text)
 import qualified Data.Text as Text
 import Data.Typeable
 import GHC.Generics
@@ -78,4 +82,19 @@ data ANSIColour
   | Magenta
   | Cyan
   | White
+  deriving (Show, Eq)
+
+data DirectoryEntry = DirectoryEntry ItemName ItemType
+  deriving (Show, Eq)
+
+newtype ItemName = ItemName Text
+  deriving (Show, Eq)
+
+data ItemType
+  = MarsObject
+  | MarsList
+  | MarsString
+  | MarsNumber
+  | MarsBool
+  | MarsNull
   deriving (Show, Eq)


### PR DESCRIPTION
Many of the interesting effects of the commands when evaluated are
strictly pure other than they might output to the terminal (`save` and
`load` being the only current examples which actually have other effects in
the outside world)

This observation means that we can move most of their logic outside
of the IO monad and just have an `eval` function responsible for
printing the output.

This makes it much easier to start testing the functionality of these
operations in unit tests. Testing `ls` for instance found that the
behaviour was currently correct, and in fact that the code could be a
lot simpler. ♥ Haskell