### PR TITLE
Remove limit on number of test cases

### DIFF
--- a/script/dev
+++ b/script/dev
@@ -3,7 +3,6 @@ set -euo pipefail
 IFS=$'\n\t'
 
 export TASTY_HIDE_SUCCESSES=True
-export TASTY_QUICKCHECK_TESTS=20
 
 ghcid \
   --lint \


### PR DESCRIPTION
The `script/dev` script was inherited from another project, which could
generate very instances of a complex type. (Some work needs to be done
there in order to improve the `shrink` instances). Mars' types don't
produce the same issue, so there's no need for this limit