### PR TITLE
Extract Renderable concept to own typeclass

### DIFF
--- a/Mars.cabal
+++ b/Mars.cabal
@@ -55,7 +55,8 @@ library
              , unordered-containers
              , url
              , vector
-  ghc-options: -O2 -threaded -Wall -Werror
+  ghc-options: -O2 -Wall -Werror
+  default-language:    Haskell2010
 
 executable mars
   Hs-Source-Dirs:
@@ -168,6 +169,7 @@ Test-suite test-mars
                   , unordered-containers
                   , url
                   , vector
+  default-language:    Haskell2010
 
 source-repository head
     type: git

--- a/Mars.cabal
+++ b/Mars.cabal
@@ -38,6 +38,7 @@ library
       Mars.Eval
       Mars.Parser
       Mars.Query
+      Mars.Renderable
       Mars.Types
       Tests.Mars.Arbitraries
   build-depends: QuickCheck
@@ -73,6 +74,7 @@ executable mars
       Mars.Eval
       Mars.Parser
       Mars.Query
+      Mars.Renderable
       Mars.Types
       Tests.Mars.Arbitraries
   autogen-modules:
@@ -87,6 +89,7 @@ executable mars
       Mars.Eval
       Mars.Parser
       Mars.Query
+      Mars.Renderable
       Mars.Types
       Tests.Mars.Arbitraries
   build-depends: Mars
@@ -128,6 +131,7 @@ Test-suite test-mars
       Mars.Eval
       Mars.Parser
       Mars.Query
+      Mars.Renderable
       Mars.Types
       Tests.Mars.Arbitraries
     autogen-modules:
@@ -142,6 +146,7 @@ Test-suite test-mars
       Mars.Eval
       Mars.Parser
       Mars.Query
+      Mars.Renderable
       Mars.Types
       Tests.Mars.Arbitraries
 

--- a/src/Mars/Command.hs
+++ b/src/Mars/Command.hs
@@ -11,7 +11,6 @@ module Mars.Command
     moveUp,
     normalizeQuery,
     queryDoc,
-    renderQuery,
   )
 where
 
@@ -32,7 +31,6 @@ import Prelude hiding ((.), id)
 class Command a where
   evalCommand :: MarsState -> a -> (MarsState, Output)
   printCommand :: a -> (MarsState, Output) -> IO MarsState
-  renderCommand :: a -> Text
 
 -- | A text version of a QueryItem
 moveUp :: Query -> Maybe Query

--- a/src/Mars/Command/Cat.hs
+++ b/src/Mars/Command/Cat.hs
@@ -12,6 +12,7 @@ import Data.Typeable
 import GHC.Generics
 import Mars.Command
 import Mars.Query
+import Mars.Renderable
 import Mars.Types
 import Test.QuickCheck
 import Prelude hiding (putStrLn)
@@ -43,7 +44,9 @@ instance Command Cat where
   printCommand _ (state, Output o) = do
     putStrLn o
     return state
-  renderCommand (Cat l) = Text.intercalate " " $ "cat" : (renderQuery <$> l)
+
+instance Renderable Cat where
+  render (Cat l) = Text.intercalate " " $ "cat" : (render <$> l)
 
 instance Arbitrary Cat where
   arbitrary = Cat <$> arbitrary

--- a/src/Mars/Command/Cd.hs
+++ b/src/Mars/Command/Cd.hs
@@ -8,11 +8,10 @@ import Data.Typeable
 import GHC.Generics
 import Mars.Command
 import Mars.Query (Query)
+import Mars.Renderable
 import Mars.Types
 import Test.QuickCheck
 import Prelude hiding (putStrLn)
-
--- import Text.ParserCombinators.Parsec hiding ((<|>))
 
 newtype Cd = Cd Query
   deriving (Generic, Show, Eq, Typeable)
@@ -32,7 +31,9 @@ instance Command Cd where
   printCommand _ (state, Output o) = do
     putStrLn o
     return state
-  renderCommand (Cd a) = "cd " <> renderQuery a
+
+instance Renderable Cd where
+  render (Cd a) = "cd " <> render a
 
 instance Arbitrary Cd where
   arbitrary = Cd <$> arbitrary

--- a/src/Mars/Command/Load.hs
+++ b/src/Mars/Command/Load.hs
@@ -12,6 +12,7 @@ import Mars.Command
 import Mars.Types
 import System.IO (hPutStrLn, stderr)
 import Test.QuickCheck
+import Mars.Renderable
 
 newtype Load = Load Text
   deriving (Generic, Show, Eq, Typeable)
@@ -27,7 +28,9 @@ instance Command Load where
       reportResult (Aeson.Error err) = printErr err
       reportResult (Aeson.Success state) = pure state
       printErr err = s <$ hPutStrLn stderr ("Invalid saved state: " <> err)
-  renderCommand (Load f) = "load \"" <> f <> "\""
+
+instance Renderable Load where
+  render (Load f) = "load \"" <> f <> "\""
 
 instance Arbitrary Load where
   arbitrary = Load <$> arbString

--- a/src/Mars/Command/Ls.hs
+++ b/src/Mars/Command/Ls.hs
@@ -18,6 +18,7 @@ import qualified Data.Vector as Vector
 import GHC.Generics
 import Mars.Command
 import Mars.Query (Query (..))
+import Mars.Renderable
 import Mars.Types
 import Test.QuickCheck
 import Prelude hiding (putStrLn)
@@ -47,7 +48,9 @@ instance Command Ls where
   printCommand _ (state, Output o) = do
     putStrLn o
     return state
-  renderCommand (Ls a) = "ls " <> renderQuery a
+
+instance Renderable Ls where
+  render (Ls a) = "ls " <> render a
 
 list :: Value -> Query -> [DirectoryEntry]
 list doc query =

--- a/src/Mars/Command/Pwd.hs
+++ b/src/Mars/Command/Pwd.hs
@@ -7,6 +7,7 @@ import Data.Text.IO (putStrLn)
 import Data.Typeable
 import GHC.Generics
 import Mars.Command
+import Mars.Renderable
 import Mars.Types
 import Test.QuickCheck
 import Prelude hiding (putStrLn)
@@ -15,11 +16,13 @@ data Pwd = Pwd
   deriving (Generic, Show, Eq, Typeable)
 
 instance Command Pwd where
-  evalCommand s Pwd = (s, Output . renderQuery . path $ s)
+  evalCommand s Pwd = (s, Output . render . path $ s)
   printCommand _ (state, Output o) = do
     putStrLn o
     return state
-  renderCommand Pwd = "pwd"
+
+instance Renderable Pwd where
+  render Pwd = "pwd"
 
 instance Arbitrary Pwd where
   arbitrary = pure Pwd

--- a/src/Mars/Command/Save.hs
+++ b/src/Mars/Command/Save.hs
@@ -10,6 +10,7 @@ import Data.Text (Text)
 import Data.Typeable
 import GHC.Generics
 import Mars.Command
+import Mars.Renderable
 import Mars.Types
 import Test.QuickCheck
 
@@ -22,7 +23,8 @@ instance Command Save where
     where
       jsonString = toS . encodePretty $ toJSON s
 
-  renderCommand (Save f) = "save " <> f
+instance Renderable Save where
+  render (Save f) = "save " <> f
 
 instance Arbitrary Save where
   arbitrary = Save <$> arbString

--- a/src/Mars/Command/Set.hs
+++ b/src/Mars/Command/Set.hs
@@ -5,18 +5,19 @@
 
 module Mars.Command.Set (Set (..)) where
 
-import Data.Text.IO (putStrLn)
-import Prelude hiding (putStrLn)
 import Data.Aeson
 import Data.String.Conv
 import Data.Text (Text)
+import Data.Text.IO (putStrLn)
 import Data.Typeable
 import qualified Data.Vector as Vector
 import GHC.Generics
 import Mars.Command
 import Mars.Query (Query)
+import Mars.Renderable
 import Mars.Types
 import Test.QuickCheck
+import Prelude hiding (putStrLn)
 
 data Set = Set Query Value
   deriving (Generic, Show, Eq, Typeable)
@@ -31,9 +32,11 @@ instance Command Set where
   printCommand _ (state, Output o) = do
     putStrLn o
     return state
-  renderCommand (Set q val) =
+
+instance Renderable Set where
+  render (Set q val) =
     "set "
-      <> renderQuery q
+      <> render q
       <> " "
       <> (toS . encode $ val)
 

--- a/src/Mars/Renderable.hs
+++ b/src/Mars/Renderable.hs
@@ -1,0 +1,6 @@
+module Mars.Renderable where
+import Data.Text
+
+class Renderable a where
+  render :: a -> Text
+

--- a/src/Mars/Types.hs
+++ b/src/Mars/Types.hs
@@ -27,6 +27,7 @@ data MarsState = MarsState
   deriving (Generic)
 
 instance FromJSON MarsState
+
 instance ToJSON MarsState
 
 data ANSIColour

--- a/src/Tests/Mars/Main.hs
+++ b/src/Tests/Mars/Main.hs
@@ -16,6 +16,7 @@ import Mars.Command.Ls
 import Mars.Command.Pwd
 import Mars.Parser
 import Mars.Query
+import Mars.Renderable
 import Mars.Types
 import Test.Tasty
 import Test.Tasty.HUnit
@@ -225,30 +226,30 @@ testNestedObject = queryDoc q v @?= [toJSON ("Test" :: Text)]
         ]
 
 prop_command_parse :: Operation -> Bool
-prop_command_parse (OpCat c) = case parser . renderCommand $ c of
+prop_command_parse (OpCat c) = case parser . render $ c of
   Right ((OpCat x) : _) -> x == c
   _ -> False
-prop_command_parse (OpCd c) = case parser . renderCommand $ c of
+prop_command_parse (OpCd c) = case parser . render $ c of
   Right ((OpCd x) : _) -> x == c
   _ -> False
-prop_command_parse (OpLoad c) = case parser . renderCommand $ c of
+prop_command_parse (OpLoad c) = case parser . render $ c of
   Right ((OpLoad x) : _) -> x == c
   _ -> False
-prop_command_parse (OpLs c) = case parser . renderCommand $ c of
+prop_command_parse (OpLs c) = case parser . render $ c of
   Right ((OpLs x) : _) -> x == c
   _ -> False
-prop_command_parse (OpPwd c) = case parser . renderCommand $ c of
+prop_command_parse (OpPwd c) = case parser . render $ c of
   Right ((OpPwd x) : _) -> x == c
   _ -> False
-prop_command_parse (OpSave c) = case parser . renderCommand $ c of
+prop_command_parse (OpSave c) = case parser . render $ c of
   Right ((OpSave x) : _) -> x == c
   _ -> False
-prop_command_parse (OpSet c) = case parser . renderCommand $ c of
+prop_command_parse (OpSet c) = case parser . render $ c of
   Right ((OpSet x) : _) -> x == c
   _ -> False
 
 prop_query_parse :: Query -> Bool
-prop_query_parse q = case parseQuery . renderQuery $ q of
+prop_query_parse q = case parseQuery . render $ q of
   Left _ -> False
   Right qry -> qry == q
 


### PR DESCRIPTION
Printing the elements of a Mars command line is something which we do
for a number of different types now. It can be extracted into its own
typeclass, rather than in various different functions, and the Command
typeclass